### PR TITLE
fix(ci): use RELEASE_TOKEN for semantic-release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -27,4 +28,4 @@ jobs:
 
       - run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
The default GITHUB_TOKEN push is rejected by the protect-main ruleset's require-pull-request rule. RELEASE_TOKEN is a PAT owned by a repository admin, which is exempted via the ruleset's bypass list.